### PR TITLE
Wallet

### DIFF
--- a/contracts/SimpleWallet.sol
+++ b/contracts/SimpleWallet.sol
@@ -6,6 +6,7 @@ import "./BaseWallet.sol";
 import "./lib/ECDSA.sol";
 import "./lib/UserOperation.sol";
 import "./EntryPoint.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /* solhint-disable avoid-low-level-calls */
 /* solhint-disable no-inline-assembly */
@@ -40,9 +41,16 @@ contract SimpleWallet is BaseWallet {
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {}
 
-    constructor(EntryPoint anEntryPoint, address anOwner) {
+    constructor(
+        EntryPoint anEntryPoint,
+        address anOwner,
+        address gasToken,
+        address paymaster,
+        uint256 amount
+    ) {
         _entryPoint = anEntryPoint;
         owner = anOwner;
+        if (gasToken != address(0)) IERC20(gasToken).approve(paymaster, amount);
     }
 
     modifier onlyOwner() {

--- a/contracts/SimpleWalletUpgradeable.sol
+++ b/contracts/SimpleWalletUpgradeable.sol
@@ -9,7 +9,7 @@ import "./EntryPoint.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/StorageSlot.sol";
 import "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
-import "hardhat/console.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /* solhint-disable avoid-low-level-calls */
 /* solhint-disable no-inline-assembly */
@@ -53,12 +53,12 @@ contract SimpleWalletUpgradeable is BaseWallet, Initializable, DefaultCallbackHa
         EntryPoint anEntryPoint,
         address anOwner,
         address gasToken,
-        bytes calldata functionData
+        address paymaster,
+        uint256 amount
     ) public initializer {
         _entryPoint = anEntryPoint;
-        // set by proxy constructor
         _setAdmin(anOwner);
-        if (gasToken != address(0)) address(gasToken).call(functionData);
+        if (gasToken != address(0)) IERC20(gasToken).approve(paymaster, amount);
     }
 
     modifier onlyOwner() {


### PR DESCRIPTION
Explicit calling IERC20:approve on wallet deployment for clearer indication what it is doing. 

Adjusted testing for the new constructor/initializer.

Added testing for:
1. Two userOperation in one transaction
2. Sending transaction when the wallet is not actually deployed, (generate `initCode` in userOperation)